### PR TITLE
Fix imports when launching GUI directly

### DIFF
--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -30,6 +30,15 @@ from PySide6.QtMultimedia import QMediaPlayer, QAudioOutput
 # Python sets up the package import path automatically so no manual
 # modification of ``sys.path`` is required.
 
+# Support execution both as ``python -m src.ui.main_window`` and as a script.
+if __package__ in (None, ""):  # pragma: no cover - CLI/GUI
+    # When run directly (e.g. ``python src/ui/main_window.py``), ``src``
+    # won't be on ``sys.path``.  Add the repository root so that the
+    # ``src`` package can be imported.
+    repo_root = Path(__file__).resolve().parents[2]
+    if str(repo_root) not in sys.path:
+        sys.path.insert(0, str(repo_root))
+
 from src.core.diarize import Diarizer
 from src.core.splitter import SegmentSplitter
 from src.core.transcriber import Transcriber


### PR DESCRIPTION
## Summary
- ensure `src` package is on the path when executing `src/ui/main_window.py` directly

## Testing
- `python -m py_compile src/ui/main_window.py`

------
https://chatgpt.com/codex/tasks/task_e_6848200592b08333bad5450a0c1a92c5