### PR TITLE
Fix README for pyannote install

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 
 ## セットアップ
 
+Python 3.10での利用を推奨します。pyannote.audio 2.x は torchaudio <1.0 に依存し、Python 3.11 以降には対応していません。
 ```bash
 # Python 3 を python3 として呼び出す環境では以下を使用
 python3 -m venv venv


### PR DESCRIPTION
## Summary
- document Python 3.10 requirement in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6848dc6603548333b1a4a6ac226597ae