### PR TITLE
Improve diarization pipeline outputs

### DIFF
--- a/4_merge_results.py
+++ b/4_merge_results.py
@@ -12,7 +12,7 @@ parser = argparse.ArgumentParser(description="Merge diarization and transcripts"
 parser.add_argument("-d", "--diar", required=True, help="Diarization JSON")
 parser.add_argument("-t", "--trans", required=True, help="Transcription JSON")
 parser.add_argument("-m", "--map", required=False, help="Mapping YAML (unused)")
-parser.add_argument("-o", "--output", required=True, help="Output TXT")
+parser.add_argument("-o", "--output", required=True, help="Output file (.json or .csv)")
 
 args = parser.parse_args()
 

--- a/README.md
+++ b/README.md
@@ -51,10 +51,10 @@ Windows では `build_scripts/build_win_exe.sh` を実行して単一の EXE を
 python 1_diarize.py -i audio\sample.wav -o output\diarization.json
 python 2_split_segments.py -i audio\sample.wav -d output\diarization.json -o segments
 python 3_transcribe.py -i segments -o output\transcriptions.json
-python 4_merge_results.py -d output\diarization.json -t output\transcriptions.json -o output\final.txt
+python 4_merge_results.py -d output\diarization.json -t output\transcriptions.json -o output\final.json
 ```
 
-最後に `output\final.txt` に話者ラベル付きの文字起こし結果が生成されます。
+最後に `output\final.json` もしくは拡張子を `.csv` にしたファイルに、話者ラベル付きの文字起こし結果が生成されます。
 
 ## サンプル音声
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
-requests
+openai-whisper
 pydub
 tqdm
-numpy
 PySide6>=6.5
-sentencepiece==0.2.0
-git+https://github.com/openai/whisper.git
+sentencepiece
+requests

--- a/src/core/diarize.py
+++ b/src/core/diarize.py
@@ -29,7 +29,7 @@ class Diarizer:
 
         with open(path_to_use, "rb") as f:
             response = requests.post(
-                "https://api-inference.huggingface.co/models/pyannote/speaker-diarization",
+                "https://api-inference.huggingface.co/models/pyannote/speaker-diarization@2023.07",
                 headers={"Authorization": f"Bearer {self.token}"},
                 data=f,
             )

--- a/src/core/merger.py
+++ b/src/core/merger.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import csv
 import json
 import logging
 from pathlib import Path
@@ -16,15 +17,27 @@ class Merger:
         diar_json: Path,
         trans_json: Path,
         mapping: Dict[str, str],
-        output_txt: Path,
+        output_path: Path,
     ) -> Path:
         diar = json.loads(diar_json.read_text())
         trans = {t["file"]: t["text"] for t in json.loads(trans_json.read_text())}
-        lines = []
+        results = []
         for i, seg in enumerate(diar):
             speaker = mapping.get(seg.get("speaker", ""), seg.get("speaker"))
             text = trans.get(f"segment_{i:04d}.wav", "")
-            lines.append(f"[{speaker}] {text}")
-        output_txt.write_text("\n".join(lines))
-        logger.info("Final transcript saved to %s", output_txt)
-        return output_txt
+            results.append({"speaker": speaker, "text": text})
+
+        if output_path.suffix.lower() == ".json":
+            output_path.write_text(json.dumps(results, ensure_ascii=False, indent=2))
+        elif output_path.suffix.lower() == ".csv":
+            with output_path.open("w", newline="", encoding="utf-8") as f:
+                writer = csv.writer(f)
+                writer.writerow(["speaker", "text"])
+                for row in results:
+                    writer.writerow([row["speaker"], row["text"]])
+        else:
+            lines = [f"[{r['speaker']}] {r['text']}" for r in results]
+            output_path.write_text("\n".join(lines))
+
+        logger.info("Final transcript saved to %s", output_path)
+        return output_path


### PR DESCRIPTION
## Summary
- change requirements to use `openai-whisper` package
- call the 2023.07 revision of the pyannote model
- allow `Merger` to output JSON or CSV
- tweak merge script arguments and docs

## Testing
- `python -m py_compile 4_merge_results.py src/core/*.py`

------
https://chatgpt.com/codex/tasks/task_e_684905201aa483339b7126994ffe1881